### PR TITLE
feat: Rewrite to TypeScript and configure for NPM/JSR publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ It allows you to programmatically create conversations, generate text and image 
 
 ## Installation
 
-This library is not yet published to a package manager. To use it, you can clone this repository and import directly from the `src` directory.
+This package is available on both JSR (the JavaScript Registry) and NPM. For Bun and Deno users, **JSR is the recommended** choice.
 
-In the future, you will be able to install it via:
+### JSR (Recommended)
 ```bash
-# Not yet available
-bun add twikit-grok-ts
+bunx jsr add @ptt/twikit-grok-ts
+```
+
+### NPM
+```bash
+bun add @potetotown/twikit-grok-ts
 ```
 
 ## Authentication
@@ -36,22 +40,18 @@ Set the `TWITTER_COOKIE` environment variable to your full cookie string from yo
 export TWITTER_COOKIE='ct0=...; auth_token=...; ...'
 ```
 
-The client will automatically pick up this environment variable.
+The client will automatically use this environment variable if no cookie is passed to the constructor.
 
 ## Quick Start
 
-Here’s a quick example of how to use the library. Make sure you have set the `TWITTER_COOKIE` environment variable before running the script.
+Here’s a quick example of how to use the library. Make sure you have set the `TWITTER_COOKIE` environment variable before running.
 
 ```typescript
-// examples/quick-start.ts
-import { Client } from './src/index';
+import { Client } from '@ptt/twikit-grok-ts';
 
-const client = new Client({
-    // The client constructor will look for the TWITTER_COOKIE env var
-    // if the `cookies` option is not provided. For clarity, we can
-    // pass it explicitly.
-    cookies: process.env.TWITTER_COOKIE
-});
+// The client constructor will automatically use the `TWITTER_COOKIE`
+// environment variable if the `cookies` option is not provided.
+const client = new Client();
 
 async function main() {
     try {
@@ -82,9 +82,4 @@ async function main() {
 }
 
 main();
-```
-
-To run the example from the root of the project:
-```bash
-bun run examples/quick-start.ts
 ```

--- a/package.json
+++ b/package.json
@@ -1,12 +1,28 @@
 {
-  "name": "/app",
-  "module": "index.ts",
+  "name": "@potetotown/twikit-grok-ts",
+  "version": "0.1.0",
+  "description": "A TypeScript client for the Grok API on X (formerly Twitter), running on Bun.",
   "type": "module",
-  "private": true,
-  "devDependencies": {
-    "@types/bun": "latest"
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
   },
-  "peerDependencies": {
-    "typescript": "^5"
-  }
+  "devDependencies": {
+    "bun-types": "latest",
+    "typescript": "^5.0.0"
+  },
+  "files": [
+    "src"
+  ],
+  "keywords": [
+    "grok",
+    "twitter",
+    "x",
+    "api",
+    "bun",
+    "typescript"
+  ],
+  "license": "MIT",
+  "jsr": "@ptt/twikit-grok-ts"
 }


### PR DESCRIPTION
This commit completely rewrites the original Python-based `twikit_grok` library into a modern, type-safe TypeScript project running on the Bun runtime. It also configures the project for publishing to both NPM and the JavaScript Registry (JSR).

Key changes include:
- The entire Python codebase and its related project files have been removed.
- The logic has been translated into TypeScript modules (`src/`) with strict type checking.
- The project now uses Bun's native APIs, removing all Python dependencies.
- `package.json` has been configured with names, versions, and metadata for both NPM (`@potetotown/twikit-grok-ts`) and JSR (`@ptt/twikit-grok-ts`).
- `README.md` has been overhauled with new instructions, including installation commands for both registries.
- A comprehensive example (`examples/quick-start.ts`) is provided to demonstrate library usage.